### PR TITLE
Fix: EndMenuUI 리플레이 -> Intro 상태로 변경

### DIFF
--- a/Assets/PSH/Scripts/UI_Scripts/EndMenuUI.cs
+++ b/Assets/PSH/Scripts/UI_Scripts/EndMenuUI.cs
@@ -91,7 +91,7 @@ public class EndMenuUI : MonoBehaviour
         {
             if (GameManager.Instance != null)
             {
-                GameManager.Instance.SetState(GameState.BossPhase1);
+                GameManager.Instance.SetState(GameState.Intro);
             }
             else
             {

--- a/ProjectSettings/ProjectSettings.asset
+++ b/ProjectSettings/ProjectSettings.asset
@@ -141,11 +141,7 @@ PlayerSettings:
   visionOSBundleVersion: 1.0
   tvOSBundleVersion: 1.0
   bundleVersion: 1.0.0
-  preloadedAssets:
-  - {fileID: 7409956309476867576, guid: 3fd4fc0127790db4bae83f7b77da8d45, type: 2}
-  - {fileID: 11400000, guid: c199e683398494f32b4cde18e73ab731, type: 2}
-  - {fileID: 4800000, guid: c9f956787b1d945e7b36e0516201fc76, type: 3}
-  - {fileID: 4800000, guid: 0945859e5a1034c2cb6dce53cb4fb899, type: 3}
+  preloadedAssets: []
   metroInputSource: 0
   wsaTransparentSwapchain: 0
   m_HolographicPauseOnTrackingLoss: 1


### PR DESCRIPTION
플레이어 체력 초기화 안 되던 것: 보스페이즈1 상태로 변경했기 때문에 상태 변경이 없어서 그랬던 거였음